### PR TITLE
Support OCaml 5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
           - 5.1.x
           - 5.2.x
           - 5.3.x
+          - 5.4.x
+          - 5.5.x
 
     runs-on: ubuntu-latest
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+# Next
+
+- Support OCaml 5.3, 5.4, and 5.5.
+
 # 2.25.1
 
 - Fix fatal error for OCaml 5.2.

--- a/examples/regression/src/Main.ml
+++ b/examples/regression/src/Main.ml
@@ -5,4 +5,4 @@ let () =
   Functor_argument.use_set ();
   Functor_argument.use_anonymous_set ();
   Local_side_effects.start ();
-  ignore (Ocaml_compiler_compat.run ())
+  Ocaml_compiler_compat.run ()

--- a/examples/regression/src/Main.ml
+++ b/examples/regression/src/Main.ml
@@ -4,4 +4,5 @@ let () =
   Live_ancestors.use_child ();
   Functor_argument.use_set ();
   Functor_argument.use_anonymous_set ();
-  Local_side_effects.start ()
+  Local_side_effects.start ();
+  ignore (Ocaml_compiler_compat.run ())

--- a/examples/regression/src/Ocaml_compiler_compat.ml
+++ b/examples/regression/src/Ocaml_compiler_compat.ml
@@ -1,9 +1,17 @@
+(* Exercise compiler-libs representations that changed in OCaml 5.4 and 5.5.
+   The regression ensures reanalyze can traverse the resulting typed tree
+   across all supported compiler versions. *)
+
+(* OCaml 5.4 added labels to tuple elements and an extra type field to alias
+   patterns. It also added a mutability flag to array expressions. *)
 let tuple_alias ((left, right) as pair) =
   let values = [|left; right|] in
   (pair, values)
 
 let optional ?value () = value
 
+(* OCaml 5.5 represents local modules and exceptions using Texp_struct_item
+   instead of Texp_letmodule and Texp_letexception. *)
 let local_module_value =
   let module Local = struct
     let value = 42
@@ -16,4 +24,6 @@ let local_exception_value =
 
 let run () =
   let _pair, values = tuple_alias (local_module_value, local_exception_value) in
+  (* OCaml 5.4 replaced expression options in application arguments with
+     explicit Omitted and Arg constructors. Exercise both forms. *)
   ignore (optional (), optional ~value:values.(0) ())

--- a/examples/regression/src/Ocaml_compiler_compat.ml
+++ b/examples/regression/src/Ocaml_compiler_compat.ml
@@ -1,0 +1,19 @@
+let tuple_alias ((left, right) as pair) =
+  let values = [|left; right|] in
+  (pair, values)
+
+let optional ?value () = value
+
+let local_module_value =
+  let module Local = struct
+    let value = 42
+  end in
+  Local.value
+
+let local_exception_value =
+  let exception Local_error in
+  try raise Local_error with Local_error -> 1
+
+let run () =
+  let _pair, values = tuple_alias (local_module_value, local_exception_value) in
+  (optional (), optional ~value:values.(0) ())

--- a/examples/regression/src/Ocaml_compiler_compat.ml
+++ b/examples/regression/src/Ocaml_compiler_compat.ml
@@ -2,8 +2,9 @@
    The regression ensures reanalyze can traverse the resulting typed tree
    across all supported compiler versions. *)
 
-(* OCaml 5.4 added labels to tuple elements and an extra type field to alias
-   patterns. It also added a mutability flag to array expressions. *)
+(* OCaml 5.4 changed tuple elements to carry an optional label and added an
+   extra type field to alias patterns. It also added a mutability flag to array
+   expressions. *)
 let tuple_alias ((left, right) as pair) =
   let values = [|left; right|] in
   (pair, values)

--- a/examples/regression/src/Ocaml_compiler_compat.ml
+++ b/examples/regression/src/Ocaml_compiler_compat.ml
@@ -16,4 +16,4 @@ let local_exception_value =
 
 let run () =
   let _pair, values = tuple_alias (local_module_value, local_exception_value) in
-  (optional (), optional ~value:values.(0) ())
+  ignore (optional (), optional ~value:values.(0) ())

--- a/examples/regression/src/dune
+++ b/examples/regression/src/dune
@@ -5,5 +5,6 @@
   Generated_source
   Live_ancestors
   Local_side_effects
-  Main)
+  Main
+  Ocaml_compiler_compat)
  (flags :standard -w -27-32-34-37-39 -bin-annot))

--- a/reanalyze.opam
+++ b/reanalyze.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/rescript-association/reanalyze"
 bug-reports: "https://github.com/rescript-association/reanalyze/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml" {>= "4.08.0" & < "5.3"}
+  "ocaml" {>= "4.08.0" & < "5.6"}
   "cppo" {build}
 ]
 build: [

--- a/src/Annotation.ml
+++ b/src/Annotation.ml
@@ -38,7 +38,24 @@ let rec getAttributePayload checkText (attributes : Typedtree.attributes) =
       fromExpr e
     | {pexp_desc = Pexp_construct ({txt}, _); _} ->
       Some (ConstructPayload (txt |> Longident.flatten |> String.concat "."))
-    | {pexp_desc = Pexp_tuple exprs | Pexp_array exprs} ->
+    | {pexp_desc =
+#if OCAML_VERSION >= (5, 5, 0)
+        Pexp_tuple labelledExprs} ->
+      let exprs = List.map snd labelledExprs in
+#else
+        Pexp_tuple exprs} ->
+#endif
+      let payloads =
+        exprs |> List.rev
+        |> List.fold_left
+             (fun payloads expr ->
+               match expr |> fromExpr with
+               | Some payload -> payload :: payloads
+               | None -> payloads)
+             []
+      in
+      Some (TuplePayload payloads)
+    | {pexp_desc = Pexp_array exprs} ->
       let payloads =
         exprs |> List.rev
         |> List.fold_left

--- a/src/Annotation.ml
+++ b/src/Annotation.ml
@@ -39,7 +39,7 @@ let rec getAttributePayload checkText (attributes : Typedtree.attributes) =
     | {pexp_desc = Pexp_construct ({txt}, _); _} ->
       Some (ConstructPayload (txt |> Longident.flatten |> String.concat "."))
     | {pexp_desc =
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
         Pexp_tuple labelledExprs} ->
       let exprs = List.map snd labelledExprs in
 #else

--- a/src/Arnold.ml
+++ b/src/Arnold.ml
@@ -565,7 +565,11 @@ module ExtendFunctionTable = struct
         let functionName = Path.name callee in
         args
         |> List.iter (fun ((argLabel : Asttypes.arg_label), argOpt) ->
-               match (argLabel, argOpt |> extractLabelledArgument) with
+               match
+                 ( argLabel,
+                   argOpt |> Compat.applyArgToOption
+                   |> extractLabelledArgument )
+               with
                | Labelled label, Some (path, loc)
                  when path |> FunctionTable.isInFunctionInTable ~functionTable
                  ->
@@ -607,7 +611,10 @@ module CheckExpressionWellFormed = struct
         let functionName = Path.name functionPath in
         args
         |> List.iter (fun ((argLabel : Asttypes.arg_label), argOpt) ->
-               match argOpt |> ExtendFunctionTable.extractLabelledArgument with
+               match
+                 argOpt |> Compat.applyArgToOption
+                 |> ExtendFunctionTable.extractLabelledArgument
+               with
                | Some (path, loc) -> (
                  match argLabel with
                  | Labelled label -> (
@@ -690,7 +697,7 @@ module Compile = struct
             innerFunctionDefinition.kind
             |> List.map (fun (entry : Kind.entry) ->
                    ( Asttypes.Labelled entry.label,
-                     Some
+                     Compat.applyArgOfExpression
                        {
                          expr with
                          exp_desc =
@@ -713,11 +720,14 @@ module Compile = struct
             args
             |> List.find_opt (fun arg ->
                    match arg with
-                   | Asttypes.Labelled s, Some _ -> s = label
+                   | Asttypes.Labelled s, arg ->
+                     Compat.applyArgToOption arg <> None && s = label
                    | _ -> false)
           in
           let argOpt =
-            match argOpt with Some (_, Some e) -> Some e | _ -> None
+            match argOpt with
+            | Some (_, arg) -> Compat.applyArgToOption arg
+            | _ -> None
           in
           let functionArg () =
             match
@@ -903,7 +913,14 @@ module Compile = struct
       |> Command.unorderedSequence
     | Texp_setfield (e1, _loc, _desc, e2) ->
       [e1; e2] |> List.map (expression ~ctx) |> Command.unorderedSequence
-    | Texp_tuple expressions | Texp_array expressions ->
+    | Texp_tuple expressions ->
+      expressions |> Compat.tupleExpressions
+      |> List.map (expression ~ctx) |> Command.unorderedSequence
+#if OCAML_VERSION >= (5, 5, 0)
+    | Texp_array (_, expressions) ->
+#else
+    | Texp_array expressions ->
+#endif
       expressions |> List.map (expression ~ctx) |> Command.unorderedSequence
     | Texp_assert _ -> Command.nothing
     | Texp_try _ ->
@@ -934,11 +951,13 @@ module Compile = struct
     | Texp_override _ ->
       notImplemented "Texp_override";
       assert false
-    | Texp_letmodule _ ->
-      notImplemented "Texp_letmodule";
-      assert false
-    | Texp_letexception _ ->
-      notImplemented "Texp_letexception";
+#if OCAML_VERSION >= (5, 5, 0)
+    | Texp_struct_item _ ->
+      notImplemented "Texp_struct_item";
+#else
+    | Texp_letmodule _ | Texp_letexception _ ->
+      notImplemented "Texp_letmodule/Texp_letexception";
+#endif
       assert false
     | Texp_lazy _ ->
       notImplemented "Texp_lazy";
@@ -966,7 +985,9 @@ module Compile = struct
   and evalArgs ~args ~ctx command =
     (* Don't assume any evaluation order on the arguments *)
     let commands =
-      args |> List.map (fun (_, eOpt) -> eOpt |> expressionOpt ~ctx)
+      args
+      |> List.map (fun (_, arg) ->
+             arg |> Compat.applyArgToOption |> expressionOpt ~ctx)
     in
     let open Command in
     unorderedSequence commands +++ command

--- a/src/Arnold.ml
+++ b/src/Arnold.ml
@@ -916,7 +916,7 @@ module Compile = struct
     | Texp_tuple expressions ->
       expressions |> Compat.tupleExpressions
       |> List.map (expression ~ctx) |> Command.unorderedSequence
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
     | Texp_array (_, expressions) ->
 #else
     | Texp_array expressions ->

--- a/src/Compat.ml
+++ b/src/Compat.ml
@@ -269,35 +269,35 @@ let constant_desc d =
 #endif
 
 let tupleExpressions xs =
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
   List.map snd xs
 #else
   xs
 #endif
 
 let tupleTypes xs =
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
   List.map snd xs
 #else
   xs
 #endif
 
 let tuplePatterns xs =
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
   List.map snd xs
 #else
   xs
 #endif
 
 let applyArgToOption arg =
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
   match arg with Typedtree.Arg e -> Some e | Typedtree.Omitted () -> None
 #else
   arg
 #endif
 
 let applyArgOfExpression e =
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
   Typedtree.Arg e
 #else
   Some e

--- a/src/Compat.ml
+++ b/src/Compat.ml
@@ -268,6 +268,41 @@ let constant_desc d =
   d
 #endif
 
+let tupleExpressions xs =
+#if OCAML_VERSION >= (5, 5, 0)
+  List.map snd xs
+#else
+  xs
+#endif
+
+let tupleTypes xs =
+#if OCAML_VERSION >= (5, 5, 0)
+  List.map snd xs
+#else
+  xs
+#endif
+
+let tuplePatterns xs =
+#if OCAML_VERSION >= (5, 5, 0)
+  List.map snd xs
+#else
+  xs
+#endif
+
+let applyArgToOption arg =
+#if OCAML_VERSION >= (5, 5, 0)
+  match arg with Typedtree.Arg e -> Some e | Typedtree.Omitted () -> None
+#else
+  arg
+#endif
+
+let applyArgOfExpression e =
+#if OCAML_VERSION >= (5, 5, 0)
+  Typedtree.Arg e
+#else
+  Some e
+#endif
+
 let extractValueDependencies ~cmtFilePath (cmt_infos : Cmt_format.cmt_infos) =
 #if OCAML_VERSION >= (5, 3, 0)
   let module UidTbl = Shape.Uid.Tbl in

--- a/src/DeadCommon.ml
+++ b/src/DeadCommon.ml
@@ -341,7 +341,7 @@ module ProcessDeadAnnotations = struct
       | Tpat_alias ({pat_desc = Tpat_any}, id, {loc = {loc_start = pos}}) ->
       #else
       | Tpat_var (id, {loc = {loc_start = pos}}, _)
-      #if OCAML_VERSION >= (5, 5, 0)
+      #if OCAML_VERSION >= (5, 4, 0)
       | Tpat_alias ({pat_desc = Tpat_any}, id, {loc = {loc_start = pos}}, _, _) ->
       #else
       | Tpat_alias ({pat_desc = Tpat_any}, id, {loc = {loc_start = pos}}, _) ->

--- a/src/DeadCommon.ml
+++ b/src/DeadCommon.ml
@@ -341,7 +341,11 @@ module ProcessDeadAnnotations = struct
       | Tpat_alias ({pat_desc = Tpat_any}, id, {loc = {loc_start = pos}}) ->
       #else
       | Tpat_var (id, {loc = {loc_start = pos}}, _)
+      #if OCAML_VERSION >= (5, 5, 0)
+      | Tpat_alias ({pat_desc = Tpat_any}, id, {loc = {loc_start = pos}}, _, _) ->
+      #else
       | Tpat_alias ({pat_desc = Tpat_any}, id, {loc = {loc_start = pos}}, _) ->
+      #endif
       #endif
         if !currentlyDisableWarnings then pos |> annotateLive;
         vb_attributes

--- a/src/DeadValue.ml
+++ b/src/DeadValue.ml
@@ -27,8 +27,13 @@ let collectValueBinding super self (vb : Typedtree.value_binding) =
         ({pat_desc = Tpat_any}, id, {loc = {loc_start; loc_ghost} as loc})
     #else
     | Tpat_var (id, {loc = {loc_start; loc_ghost} as loc}, _)
+    #if OCAML_VERSION >= (5, 5, 0)
+    | Tpat_alias
+        ({pat_desc = Tpat_any}, id, {loc = {loc_start; loc_ghost} as loc}, _, _)
+    #else
     | Tpat_alias
         ({pat_desc = Tpat_any}, id, {loc = {loc_start; loc_ghost} as loc}, _)
+    #endif
     #endif
       when (not loc_ghost) && not vb.vb_loc.loc_ghost ->
       let name = Ident.name id |> Name.create ~isInterface:false in
@@ -91,6 +96,9 @@ let collectValueBinding super self (vb : Typedtree.value_binding) =
   r
 
 let processOptionalArgs ~expType ~(locFrom : Location.t) ~locTo ~path args =
+  let args =
+    List.map (fun (lbl, arg) -> (lbl, Compat.applyArgToOption arg)) args
+  in
   if expType |> DeadOptionalArgs.hasOptionalArgs then (
     let supplied = ref [] in
     let suppliedMaybe = ref [] in
@@ -260,7 +268,13 @@ let collectPattern :
   (match pat.pat_desc with
   | Typedtree.Tpat_record (cases, _clodsedFlag) ->
     cases
-    |> List.iter (fun (_loc, {Types.lbl_loc = {loc_start = posTo}}, _pat) ->
+    |> List.iter (fun (_loc, {
+#if OCAML_VERSION >= (5, 5, 0)
+                              Data_types.lbl_loc
+#else
+                              Types.lbl_loc
+#endif
+                                = {loc_start = posTo}}, _pat) ->
            if !Config.analyzeTypes then
              DeadType.addTypeReference ~posFrom ~posTo)
   | _ -> ());

--- a/src/DeadValue.ml
+++ b/src/DeadValue.ml
@@ -27,7 +27,7 @@ let collectValueBinding super self (vb : Typedtree.value_binding) =
         ({pat_desc = Tpat_any}, id, {loc = {loc_start; loc_ghost} as loc})
     #else
     | Tpat_var (id, {loc = {loc_start; loc_ghost} as loc}, _)
-    #if OCAML_VERSION >= (5, 5, 0)
+    #if OCAML_VERSION >= (5, 4, 0)
     | Tpat_alias
         ({pat_desc = Tpat_any}, id, {loc = {loc_start; loc_ghost} as loc}, _, _)
     #else
@@ -269,7 +269,7 @@ let collectPattern :
   | Typedtree.Tpat_record (cases, _clodsedFlag) ->
     cases
     |> List.iter (fun (_loc, {
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
                               Data_types.lbl_loc
 #else
                               Types.lbl_loc

--- a/src/Exception.ml
+++ b/src/Exception.ml
@@ -271,6 +271,9 @@ let traverseAst () =
     | _ -> false
   in
   let raiseArgs args =
+    let args =
+      args |> List.map (fun (lbl, arg) -> (lbl, Compat.applyArgToOption arg))
+    in
     match args with
     | [(_, Some {Typedtree.exp_desc = Texp_construct ({txt}, _, _)})] ->
       [Exn.fromLid txt] |> Exceptions.fromList
@@ -310,27 +313,35 @@ let traverseAst () =
         :: !currentEvents
     | Texp_apply
         ( {exp_desc = Texp_ident (_, _, atat)},
-          [(_lbl1, Some {exp_desc = Texp_ident (_, _, val_desc)}); arg] )
+          [arg1; arg] )
       when (* raise @@ Exn(...) *)
-           atat |> isApply && val_desc |> isRaise ->
+           atat |> isApply
+           && (match snd arg1 |> Compat.applyArgToOption with
+              | Some {exp_desc = Texp_ident (_, _, val_desc)} -> isRaise val_desc
+              | _ -> false) ->
       let exceptions = [arg] |> raiseArgs in
       currentEvents := {Event.exceptions; loc; kind = Raises} :: !currentEvents;
-      arg |> snd |> iterExprOpt self
+      arg |> snd |> Compat.applyArgToOption |> iterExprOpt self
     | Texp_apply
         ( {exp_desc = Texp_ident (_, _, atat)},
-          [arg; (_lbl1, Some {exp_desc = Texp_ident (_, _, val_desc)})] )
+          [arg; arg2] )
       when (*  Exn(...) |> raise *)
-           atat |> isRevapply && val_desc |> isRaise ->
+           atat |> isRevapply
+           && (match snd arg2 |> Compat.applyArgToOption with
+              | Some {exp_desc = Texp_ident (_, _, val_desc)} -> isRaise val_desc
+              | _ -> false) ->
       let exceptions = [arg] |> raiseArgs in
       currentEvents := {Event.exceptions; loc; kind = Raises} :: !currentEvents;
-      arg |> snd |> iterExprOpt self
+      arg |> snd |> Compat.applyArgToOption |> iterExprOpt self
     | Texp_apply (({exp_desc = Texp_ident (_, _, val_desc)} as e), args) ->
       if val_desc |> isRaise then
         let exceptions = args |> raiseArgs in
         currentEvents :=
           {Event.exceptions; loc; kind = Raises} :: !currentEvents
       else e |> iterExpr self;
-      args |> List.iter (fun (_, eOpt) -> eOpt |> iterExprOpt self)
+      args
+      |> List.iter (fun (_, arg) ->
+             arg |> Compat.applyArgToOption |> iterExprOpt self)
     | Texp_match _ ->
       let e, cases, partial = Compat.getTexpMatch expr.exp_desc in
       let exceptionPatterns = expr.exp_desc |> Compat.texpMatchGetExceptions in

--- a/src/Il.ml
+++ b/src/Il.ml
@@ -29,7 +29,12 @@ module Kind = struct
       Arrow
         ( declTypes |> List.map (fun (_lbl, t) -> t |> fromType) |> Array.of_list,
           retType |> fromType )
-    | Ttuple ts -> Tuple (ts |> List.map fromType)
+    | Ttuple ts ->
+#if OCAML_VERSION >= (5, 5, 0)
+      Tuple (ts |> List.map (fun (_, t) -> fromType t))
+#else
+      Tuple (ts |> List.map fromType)
+#endif
     | _ -> Star
 end
 

--- a/src/Il.ml
+++ b/src/Il.ml
@@ -30,7 +30,7 @@ module Kind = struct
         ( declTypes |> List.map (fun (_lbl, t) -> t |> fromType) |> Array.of_list,
           retType |> fromType )
     | Ttuple ts ->
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
       Tuple (ts |> List.map (fun (_, t) -> fromType t))
 #else
       Tuple (ts |> List.map fromType)

--- a/src/Noalloc.ml
+++ b/src/Noalloc.ml
@@ -22,6 +22,7 @@ let processCallee ~env ~funDef ~loc callee =
 let rec processTyp ~(funDef : Il.funDef) ~loc (typ : Types.type_expr) =
   match Compat.get_desc typ with
   | Ttuple ts ->
+    let ts = Compat.tupleTypes ts in
     let scopes = ts |> List.map (processTyp ~funDef ~loc) in
     Il.Tuple scopes
   | Tlink t -> t |> processTyp ~funDef ~loc
@@ -69,7 +70,11 @@ let rec processFunDefPat ~funDef ~env ~mem (pat : Typedtree.pattern) =
   | Tpat_alias ({pat_desc = Tpat_any}, id, _) ->
   #else
   | Tpat_var (id, _, _)
+  #if OCAML_VERSION >= (5, 5, 0)
+  | Tpat_alias ({pat_desc = Tpat_any}, id, _, _, _) ->
+  #else
   | Tpat_alias ({pat_desc = Tpat_any}, id, _, _) ->
+  #endif
   #endif
     let scope = pat.pat_type |> processTyp ~funDef ~loc:pat.pat_loc in
     let newEnv =
@@ -80,6 +85,7 @@ let rec processFunDefPat ~funDef ~env ~mem (pat : Typedtree.pattern) =
     when Compat.unboxPatCstrTxt pat.pat_desc = Longident.Lident "()" ->
     (env, Il.Tuple [])
   | Tpat_tuple pats ->
+    let pats = Compat.tuplePatterns pats in
     let newEnv, scopes =
       pats
       |> List.fold_left
@@ -154,6 +160,7 @@ let rec processLocalBinding ~env ~(pat : Typedtree.pattern)
   #endif
     env |> Il.Env.add ~id:(id |> Ident.name) ~def:(LocalScope scope)
   | Tpat_tuple pats, Tuple scopes ->
+    let pats = Compat.tuplePatterns pats in
     let patsAndScopes = (List.combine pats scopes [@doesNotRaise]) in
     patsAndScopes
     |> List.fold_left
@@ -190,7 +197,7 @@ and processExpr ~funDef ~env ~mem (expr : Typedtree.expression) =
     let kind = vd.val_type |> Il.Kind.fromType in
     args
     |> List.iteri (fun i ((argLabel : Asttypes.arg_label), argOpt) ->
-           match (argLabel, argOpt) with
+           match (argLabel, Compat.applyArgToOption argOpt) with
            | Nolabel, Some (arg : Typedtree.expression) ->
              (match kind with
              | Arrow (declKinds, _) ->
@@ -221,7 +228,8 @@ and processExpr ~funDef ~env ~mem (expr : Typedtree.expression) =
           Format.fprintf ppf "Cannot decode function parameters");
       assert false);
     body |> processExpr ~funDef ~env ~mem
-  | Texp_tuple l -> l |> List.iter (processExpr ~funDef ~env ~mem)
+  | Texp_tuple l ->
+    l |> Compat.tupleExpressions |> List.iter (processExpr ~funDef ~env ~mem)
   | Texp_let (Nonrecursive, [vb], inExpr) ->
     let scope =
       vb.vb_expr.exp_type |> processTyp ~funDef ~loc:vb.vb_expr.exp_loc
@@ -248,7 +256,13 @@ and processExpr ~funDef ~env ~mem (expr : Typedtree.expression) =
   | Texp_field (e, {loc}, {lbl_name; lbl_all}) ->
     let offset = ref 0 in
     lbl_all
-    |> Array.exists (fun (ld : Types.label_description) ->
+    |> Array.exists (fun (ld :
+#if OCAML_VERSION >= (5, 5, 0)
+                             Data_types.label_description
+#else
+                             Types.label_description
+#endif
+                          ) ->
            if ld.lbl_name = lbl_name then true
            else
              let size = ld.lbl_arg |> sizeOfTyp ~loc in
@@ -277,7 +291,10 @@ let rec processGlobal ~env ~id ~mem (expr : Typedtree.expression) =
       Log_.warning ~count:false ~loc:expr.exp_loc ~name:"Noalloc" (fun ppf () ->
           Format.fprintf ppf "processGlobal Id not found: %s" id);
       assert false)
-  | Texp_tuple es -> Tuple (es |> List.map (processGlobal ~env ~id ~mem))
+  | Texp_tuple es ->
+    Tuple
+      (es |> Compat.tupleExpressions
+      |> List.map (processGlobal ~env ~id ~mem))
   | _ ->
     Log_.warning ~count:false ~loc:expr.exp_loc ~name:"Noalloc" (fun ppf () ->
         Format.fprintf ppf "processGlobal not supported yet");

--- a/src/Noalloc.ml
+++ b/src/Noalloc.ml
@@ -70,7 +70,7 @@ let rec processFunDefPat ~funDef ~env ~mem (pat : Typedtree.pattern) =
   | Tpat_alias ({pat_desc = Tpat_any}, id, _) ->
   #else
   | Tpat_var (id, _, _)
-  #if OCAML_VERSION >= (5, 5, 0)
+  #if OCAML_VERSION >= (5, 4, 0)
   | Tpat_alias ({pat_desc = Tpat_any}, id, _, _, _) ->
   #else
   | Tpat_alias ({pat_desc = Tpat_any}, id, _, _) ->
@@ -257,7 +257,7 @@ and processExpr ~funDef ~env ~mem (expr : Typedtree.expression) =
     let offset = ref 0 in
     lbl_all
     |> Array.exists (fun (ld :
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
                              Data_types.label_description
 #else
                              Types.label_description

--- a/src/SideEffects.ml
+++ b/src/SideEffects.ml
@@ -60,7 +60,7 @@ let rec exprNoSideEffects (expr : Typedtree.expression) =
   | Texp_variant (_lbl, eo) -> eo |> exprOptNoSideEffects
   | Texp_field (e, _lid, _ld) -> e |> exprNoSideEffects
   | Texp_setfield _ -> false
-#if OCAML_VERSION >= (5, 5, 0)
+#if OCAML_VERSION >= (5, 4, 0)
   | Texp_array (_, el) -> el |> List.for_all exprNoSideEffects
 #else
   | Texp_array el -> el |> List.for_all exprNoSideEffects

--- a/src/SideEffects.ml
+++ b/src/SideEffects.ml
@@ -28,7 +28,7 @@ let rec exprNoSideEffects (expr : Typedtree.expression) =
   | Texp_function _ -> true
   | Texp_apply ({exp_desc = Texp_ident (path, _, _)}, args)
     when path |> pathIsWhitelistedForSideEffects ->
-    args |> List.for_all (fun (_, eo) -> eo |> exprOptNoSideEffects)
+    args |> List.for_all (fun (_, arg) -> arg |> applyArgNoSideEffects)
   | Texp_apply _ -> false
   | Texp_sequence (e1, e2) -> e1 |> exprNoSideEffects && e2 |> exprNoSideEffects
   | Texp_let (_, vbs, e) ->
@@ -44,16 +44,27 @@ let rec exprNoSideEffects (expr : Typedtree.expression) =
     let e, cases, partial = expr.exp_desc |> Compat.getTexpMatch in
     partial = Total && e |> exprNoSideEffects
     && cases |> List.for_all caseNoSideEffects
+#if OCAML_VERSION >= (5, 5, 0)
+  | Texp_struct_item ({str_desc = Tstr_exception _ | Tstr_open _}, e) ->
+    e |> exprNoSideEffects
+  | Texp_struct_item _ -> false
+#else
   | Texp_letmodule _ -> false
+#endif
   | Texp_lazy e -> e |> exprNoSideEffects
   | Texp_try _ ->
     let e, cases = expr.exp_desc |> Compat.getTexpTry in
     e |> exprNoSideEffects && cases |> List.for_all caseNoSideEffects
-  | Texp_tuple el -> el |> List.for_all exprNoSideEffects
+  | Texp_tuple el ->
+    el |> Compat.tupleExpressions |> List.for_all exprNoSideEffects
   | Texp_variant (_lbl, eo) -> eo |> exprOptNoSideEffects
   | Texp_field (e, _lid, _ld) -> e |> exprNoSideEffects
   | Texp_setfield _ -> false
+#if OCAML_VERSION >= (5, 5, 0)
+  | Texp_array (_, el) -> el |> List.for_all exprNoSideEffects
+#else
   | Texp_array el -> el |> List.for_all exprNoSideEffects
+#endif
   | Texp_ifthenelse (e1, e2, eo) ->
     e1 |> exprNoSideEffects && e2 |> exprNoSideEffects
     && eo |> exprOptNoSideEffects
@@ -66,7 +77,9 @@ let rec exprNoSideEffects (expr : Typedtree.expression) =
   | Texp_instvar _ -> true
   | Texp_setinstvar _ -> false
   | Texp_override _ -> false
+#if OCAML_VERSION < (5, 5, 0)
   | Texp_letexception (_ec, e) -> e |> exprNoSideEffects
+#endif
   | Texp_object _ -> true
   | Texp_pack _ -> false
   | Texp_unreachable -> false
@@ -75,6 +88,9 @@ let rec exprNoSideEffects (expr : Typedtree.expression) =
 
 and exprOptNoSideEffects eo =
   match eo with None -> true | Some e -> e |> exprNoSideEffects
+
+and applyArgNoSideEffects arg =
+  arg |> Compat.applyArgToOption |> exprOptNoSideEffects
 
 and fieldNoSideEffects ((_ld, rld) : _ * Typedtree.record_label_definition) =
   match rld with


### PR DESCRIPTION
## Summary

- add compatibility helpers for OCaml 5.5 compiler-libs changes
- update the analyses for labelled tuples, application arguments, arrays, pattern aliases, structure-item expressions, and description types
- extend the supported opam range to OCaml 4.08–5.5 and add OCaml 5.4/5.5 to CI
- add regression coverage for the affected typedtree forms

## Testing

- `dune build @all` with OCaml 5.5.0
- `npm test` with OCaml 5.5.0
- `dune build @all` with OCaml 5.3.0
- `npm test` with OCaml 5.3.0
- `opam lint reanalyze.opam`
- `git diff --check`
