### PR TITLE
Make this an OCaml-only analyzer: docs, metadata, and repository URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ version [major|minor|patch|...]` command, npm will automatically tag the
 current commit, bump all the necessary version numbers (also the number in
 `src/Version.ml`) and push it to the current remote branch.
 
-Use the `...` menu next to the [tag](https://github.com/rescript-association/reanalyze/tags) to create a release manually. (To be automated later).
+Use the `...` menu next to the [tag](https://github.com/rescript-lang/reanalyze/tags) to create a release manually. (To be automated later).
 
 **Here are the concrete commands to run:**
 

--- a/EXCEPTION.md
+++ b/EXCEPTION.md
@@ -3,12 +3,12 @@
 The exception analysis is designed to keep track statically of the exceptions that might be raised at runtime. It works by issuing warnings and recognizing annotations. Warnings are issued whenever an exception is raised and not immediately caught. Annotations are used to push warnings from he local point where the exception is raised, to the outside context: callers of the current function.
 Nested functions need to be annotated separately.
 
-Instructions on how to run the exception analysis using the `-exception` and `-exception-cmt` command-line arguments, or how to add `"analysis": ["exception"]` in `bsconfig.json` are contained in the general [README.md](README.md).
+Instructions on how to run the exception analysis using the `-exception-cmt` command-line argument are contained in the general [README.md](README.md).
 
 Here's an example, where the analysis reports a warning any time an exception is raised, and not caught:
 
-```rescript
-let raises = () => raise(Not_found)
+```ocaml
+let raises () = raise Not_found
 ```
 
 reports:
@@ -16,67 +16,59 @@ reports:
 ```sh
 
   Exception Analysis
-  File "A.res", line 1, characters 4-10
-  raises might raise Not_found (A.res:1:19) and is not annotated with @raises(Not_found)
+  File "A.ml", line 1, characters 4-10
+  raises might raise Not_found (A.ml:1:16) and is not annotated with @raises(Not_found)
 ```
 
-No warning is reporteed when a `@raises` annotation is added:
+No warning is reporteed when a `[@raises]` annotation is added:
 
-```rescript
-@raises(Not_found)
-let raises = () => raise(Not_found)
+```ocaml
+let[@raises Not_found] raises () = raise Not_found
 ```
 
 When a function raises multiple exceptions, a tuple annotation is used:
 
 
-```rescript
+```ocaml
 exception A
 exception B
 
-@raises([A, B])
-let twoExceptions = (x, y) => {
-  if (x) {
-    raise(A)
-  }
-  if (y) {
-    raise(B)
-  }
-}
+let[@raises (A, B)] twoExceptions x y =
+  if x then raise A;
+  if y then raise B
 ```
 
-It is possible to silence the analysis by adding a `@doesNotRaise` annotaion:
+It is possible to silence the analysis by adding a `[@doesNotRaise]` annotaion:
 
-```rescript
-@raises(Invalid_argument)
-let stringMake1 = String.make(12, ' ')
+```ocaml
+let[@raises Invalid_argument] stringMake1 = String.make 12 ' '
 
-// Silence only the make function
-let stringMake2 = (@doesNotRaise String.make)(12, ' ')
+(* Silence only the make function *)
+let stringMake2 = (String.make [@doesNotRaise]) 12 ' '
 
-// Silence the entire call (including arguments to make)
-let stringMake3 = @doesNotRaise String.make(12, ' ')
-
+(* Silence the entire call (including arguments to make) *)
+let stringMake3 = (String.make 12 ' ' [@doesNotRaise])
 ```
 
 ## Limitations
 
-- The libraries currently modeled are limited to `Array`, `Buffer`, `Bytes`, `Char`, `Filename`, `Hashtbl`, `List`, `Pervasives`, `Str`, `String` from the standard library, and `bs-json`, and `Json` from `Js`. Models are currently vendored in the analysis, and are easy to add (see [`src/ExnLib.ml`](src/ExnLib.ml))
+- The libraries currently modeled are limited to `Array`, `Buffer`, `Bytes`, `Char`, `Filename`, `Hashtbl`, `List`, `Pervasives`, `Str`, `String` from the standard library, and `Yojson.Basic`. Models are currently vendored in the analysis, and are easy to add (see [`src/ExnLib.ml`](src/ExnLib.ml))
 - Generic exceptions are not understood by the analysis. For example `exn` is not recognized below (only concrete exceptions are):
 
-```rescript
-try (foo()) { | exn => raise(exn) }
+```ocaml
+try foo () with exn -> raise exn
 ```
 
 - Uses of e.g. `List.hd` are interpered as belonging to the standard libry. If you re-define `List` in the local scope, the analysis it will think it's dealing with `List` from the standard library.
 
 - There is no special support for functors. So with `Hashtbl.Make(...)` the builtin model will not apply. So the analysis won't report that the following can raise `Not_found`:
 
-```rescript
-module StringHash =
-  Hashtbl.Make({
-    include String
-    let hash = Hashtbl.hash
-  })
-let specializedHash = tbl => StringHash.find(tbl, "abc")
+```ocaml
+module StringHash = Hashtbl.Make (struct
+  include String
+
+  let hash = Hashtbl.hash
+end)
+
+let specializedHash tbl = StringHash.find tbl "abc"
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # reanalyze
 
-Program analysis for ReScript and OCaml projects targeting JS (ReScript) as well as native code (dune):
+Program analysis for OCaml projects built with dune:
 
 - Globally dead values, redundant optional arguments, dead modules, dead types (records and variants).
 - Exception analysis.
@@ -20,19 +20,7 @@ For the [Exception Analysis](EXCEPTION.md), build instructions are the same, and
 
 Build and run on existing projects using the Build and Try instructions below. The analysis uses `.cmt[i]` files which are generated during compilation, so should be run _after_ building your project. Remember to rebuild the project before running again.
 
-### CLI for ReScript projects
-
-```sh
-# dead code analysis
-reanalyze.exe -dce
-
-# exception analysis
-reanalyze.exe -exception
-```
-
-The requirement is that `bsconfig.json` can be found by walking up the current directory.
-
-### CLI for native projects
+### CLI
 
 ```sh
 # dead code analysis
@@ -50,17 +38,17 @@ The requirement is that the _current_ directory is where file paths start from. 
 
 The dead code analysis reports on globally dead values, redundant optional arguments, dead modules, dead types (records and variants).
 
-A value `x` is dead if it is never used, or if it is used by a value which itself is dead (transitivity). At the top level, function calls such as `Js.log(x)`, or other expressions that might cause side effects, keep value `x` live.
+A value `x` is dead if it is never used, or if it is used by a value which itself is dead (transitivity). At the top level, function calls such as `print_endline x`, or other expressions that might cause side effects, keep value `x` live.
 
-An optional argument `~argName` to a function is redundant if all the calls to the function supply the argument, or if no call does.
+An optional argument `?argName` to a function is redundant if all the calls to the function supply the argument, or if no call does.
 
 A module is considered dead if all the elements defined it in are dead.
 
 The type analysis repots on variant cases, and record labels.
 
-- A variant case `| A(int)` is dead if a value such as `A(3)` is never constructed. But it can be deconstructed via pattern matching  `| A(n) => ...` or checked for equality `x == A(3)` without making the case `A` live.
+- A variant case `| A of int` is dead if a value such as `A 3` is never constructed. But it can be deconstructed via pattern matching  `| A n -> ...` or checked for equality `x = A 3` without making the case `A` live.
 
-- A record label `x` in `type r = {x:int, y:int}` is dead if it is never read (by direct access `r.x` or pattern matching `| {x:n, y:m} => ...`). However, creating a value `let r = {x:3, y:4}` does not make `x` and `y` live.
+- A record label `x` in `type r = {x: int; y: int}` is dead if it is never read (by direct access `r.x` or pattern matching `| {x = n; y = m} -> ...`). However, creating a value `let r = {x = 3; y = 4}` does not make `x` and `y` live.
 Note that reading a value `r` does not make `r.x` or `r.y` live.
 
 While dead values can be removed automatically (see below), dead types require a bit more work. A dead variant case requires changing the type definition, and the various accesses to it. A dead record label requires changing the type definition, and removing the label from any expressions that create a value of that type.
@@ -69,14 +57,14 @@ While dead values can be removed automatically (see below), dead types require a
 
 The dead code analysis supports 2 annotations:
 
-- `@dead` suppresses reporting on the value/type, but can also be used to force the analysis to consider a value as dead. Typically used to acknowledge cases of dead code you are not planning to address right now, but can be searched easily later.
+- `[@dead]` suppresses reporting on the value/type, but can also be used to force the analysis to consider a value as dead. Typically used to acknowledge cases of dead code you are not planning to address right now, but can be searched easily later.
 
-- `@live` tells the analysis that the value should be considered live, even though it might appear to be dead. This is typically used in case of FFI where there are indirect ways to access values. In case of bucklescript projects using `genType`, export annotations immediately qualify values as live, because they are potentially reachable from JS.
+- `[@live]` tells the analysis that the value should be considered live, even though it might appear to be dead. This is typically used in case of FFI, or other indirect ways to access values, that the analysis cannot see.
 
-The main difference between `@dead` and `@live` is the transitive behaviour: `@dead` values don't keep alive values they use, while `@live` values do.
+The main difference between `[@dead]` and `[@live]` is the transitive behaviour: `[@dead]` values don't keep alive values they use, while `[@live]` values do.
 
-Several examples can be found in
-[`examples/deadcode/src/DeadTest.res`](examples/deadcode/src/DeadTest.res)
+Annotations attach to the definition, as in `let[@live] x = ...`. Several examples can be found in
+[`examples/deadcode/src/Annotations.ml`](examples/deadcode/src/Annotations.ml)
 
 ## Command-line Interface
 
@@ -92,7 +80,7 @@ reanalyze.exe -suppress one/path,another/path
 Takes a comma-separated list of path-prefixes. Report on files whose path has a prefix in the list, overriding `-suppress` (no-op if `-suppress` is not specified).
 
 ```sh
-reanalyze.exe -unsuppress one/path,another/path/File.res
+reanalyze.exe -unsuppress one/path,another/path/File.ml
 ```
 
 ### CLI -debug
@@ -111,15 +99,9 @@ This overwrites your source files automatically with dead code annotations:
 reanalyze.exe -write ...
 ```
 
-### Remove code automatically (not interactively)
-
-There's a dead code ppx (values only, not types) in this repository. It can be used to automatically remove code annotated `@dead`, as if it had been commented out.
-Can be used after adding annotations automatically. The combination of automatic annotation and automatic elimination is a form of automatic dead code elimination. For projects that use a library, or that in general have code which is dead only temporarily.
-There's obviously a level of risk in doing this automatic elimination. The safety net you can rely on is that the code must still compile.
-
 ### CLI -live-names
 
-This automatically annotates `@live` all the items called `foo` or `bar`:
+This automatically annotates `[@live]` all the items called `foo` or `bar`:
 
 ```sh
 -live-names foo,bar
@@ -127,13 +109,13 @@ This automatically annotates `@live` all the items called `foo` or `bar`:
 
 ### CLI -live-paths
 
-This automatically annotates `@live` all the items in file `Hello.res`:
+This automatically annotates `[@live]` all the items in file `Hello.ml`:
 
 ```sh
--live-paths Hello.res
+-live-paths Hello.ml
 ```
 
-This automatically annotates `@live` all the items in the `src/test` and `tmp` folders:
+This automatically annotates `[@live]` all the items in the `src/test` and `tmp` folders:
 
 ```sh
 -live-paths src/test,tmp
@@ -150,33 +132,7 @@ For example, you might want to set `_build/default` for projects that use the de
 -native-build-target _build/default
 ```
 
-## Configuration via `bsconfig.json`
-
-The `-config` option can be used to read the configuration from `bsconfig.json`: to
-set what analyses should be run, as well as `suppress` and `unsuppress` configuration.
-
-Example configuration inside `bsconfig.json`:
-```json
-{
-  "reanalyze": {
-    "analysis": ["dce", "exception"],
-    "suppress": ["src/ToSuppress.res"],
-    "unsuppress": ["this", "that"]
-  }
-}
-```
-
-This is equivalent to adding `-dce -exception -suppress src/ToSuppress.res -unsuppress this,that` to the command line in place of `-config`. Note that the options are additive, so it's possible to use e.g. `-config -exception` to add exception analysis on top of what the configuration does.
-
-## Install with npm for ReScript projects
-
-```
-npm add --save-dev reanalyze
-```
-
 ## Build From Sources
-
-### Build for OCaml native projects using dune
 
 ```sh
 opam install dune
@@ -185,16 +141,6 @@ dune build
 ```
 
 ## Try it
-
-### ReScript Projects (JS output)
-
-```sh
-npm run build # or whatever command to build the project
-npm add --save-dev reanalyze
-npx reanalyze -dce
-```
-
-### Native Projects (OCaml using dune)
 
 Make sure that `dune` builds both `.cmt` and `.cmti` files by enabling bytecode compilation. This is normally done by adding `(modes byte exe)` to the `executable` stanza in your dune file (see https://github.com/ocaml/dune/issues/3182):
 

--- a/TERMINATION.md
+++ b/TERMINATION.md
@@ -2,28 +2,27 @@
 
 If you never know when it's time to stop, don't worry. Computers don't either. The so called Halting Problem refers to the fact that a program cannot determine whether another arbitrary program terminates or not.
 
-```rescript
-let loop = n => {
-  while (n.contents > 0) {
-    n := n.contents - 1
-    print_int(n^)
-  }
-}
+```ocaml
+let loop n =
+  while !n > 0 do
+    n := !n - 1;
+    print_int !n
+  done
 ```
 
 Does this program terminate for all integers `n`? How do I make sure it does?
 
-The typical argument goes as follows. Consider a progress function on the state, and check that it's not possible to make progress infinitely often. In the example, the progress function is the distance from `n.contents ` to zero. At each iteration the number descreases, and it cannot decrease infinitely often. Therefore, the program terminates.
+The typical argument goes as follows. Consider a progress function on the state, and check that it's not possible to make progress infinitely often. In the example, the progress function is the distance from `!n` to zero. At each iteration the number descreases, and it cannot decrease infinitely often. Therefore, the program terminates.
 
 Consider now a recursive version of the program:
 
-```rescript
-let rec loop = n =>
-  if (n.contents > 0) {
-    n := n.contents - 1
-    print_int(n.contents)
-    loop(n)
-  };
+```ocaml
+let rec loop n =
+  if !n > 0 then begin
+    n := !n - 1;
+    print_int !n;
+    loop n
+  end
 ```
 
 A pattern begins to merge. There is a recursive function, and some progress happens in its body. And the argument becomes the following: every execution of the loop makes progress. So does the program terminate?
@@ -55,20 +54,19 @@ This proposed process is not just a hypothetical thought. We have several months
 
 Now back to the example:
 
-```rescript
-let progress = n =>
-  if (n.contents > 0) {
-    n := n.contents - 1
+```ocaml
+let progress n =
+  if !n > 0 then begin
+    n := !n - 1;
     true
-  } else {
-    false
-  }
+  end
+  else false
 
-let rec loop = n =>
-  if (progress(n)) {
-    print_int(n.contents)
-    loop(n)
-  }
+let[@progress progress] rec loop n =
+  if progress n then begin
+    print_int !n;
+    loop n
+  end
 ```
 
 It is not difficult to see, in isolation, that 1) the `progress` function makes progress.
@@ -80,18 +78,17 @@ The analysis **assumes** 1) and **checks** 2).
 
 If you don't opt in, nothing is checked, and no issues are reported on the following:
 
-```rescript
-let rec loop = () => loop()
+```ocaml
+let rec loop () = loop ()
 ```
 
 # Easy fail
 
-This time, opt into terminatioon checking with the `@progress` annotation. This time a potential infinite loop is reported.
+This time, opt into terminatioon checking with the `[@progress]` annotation. This time a potential infinite loop is reported.
 
 
-```rescript
-@progress
-let rec loop = () => loop()
+```ocaml
+let[@progress] rec loop () = loop ()
 ```
 
 # Progress function
@@ -100,28 +97,24 @@ This time, an actual progress function is defined, which initially does not do a
 No warnings are reported as every infinite loop makes infinite progress.
 
 
-```rescript
-let progress = () => ()
+```ocaml
+let progress () = ()
 
-@progress(progress)
-let rec loop = () => {
-  progress()
-  loop()
-}
+let[@progress progress] rec loop () =
+  progress ();
+  loop ()
 ```
 
 # A trivial mistake
 
 See what's wrong now? A possible infinite loop is reporteed.
 
-```rescript
-let progress = () => ()
+```ocaml
+let progress () = ()
 
-@progress(progress)
-let rec loop = () => {
-  loop()
-  progress()
-}
+let[@progress progress] rec loop () =
+  loop ();
+  progress ()
 ```
 
 # Let's get cheeky
@@ -129,14 +122,12 @@ let rec loop = () => {
 It's possible to play a trick, and use references to implement indirect recursion via the store,
 in the style of (Peter) Landin's knot:
 
-```rescript
-let cheekyRef = ref(() => ())
+```ocaml
+let cheekyRef = ref (fun () -> ())
 
-@progress
-let rec cheekyLoop = () => {
-  cheekyRef := cheekyLoop
-  cheekyRef.contents()
-}
+let[@progress] rec cheekyLoop () =
+  cheekyRef := cheekyLoop;
+  !cheekyRef ()
 ```
 
 This triggers a hygiene violation:
@@ -152,12 +143,10 @@ What's going on is that functions we opt into termination checking, such as `che
 Another restriction: you can't alias a function you opted into for termination checking:
 
 
-```rescript
-@progress
-let rec loop = () => {
-  let l = loop
-  l()
-}
+```ocaml
+let[@progress] rec loop () =
+  let l = loop in
+  l ()
 ```
 
 That also gives a hygiene violation error:
@@ -171,23 +160,21 @@ A progress annotation on mutually recursive functions opts them all into termina
 
 This reports an infinite loop
 
-```rescript
-@progress
-let rec foo = () => bar()
-and bar = () => foo()
+```ocaml
+let[@progress] rec foo () = bar ()
+and bar () = foo ()
 ```
 
 But this does not report:
 
-```rescript
-let progress = () => ()
+```ocaml
+let progress () = ()
 
-@progress(progress)
-let rec foo = () => bar()
-and bar = () => {
-  progress()
-  foo()
-}
+let[@progress progress] rec foo () = bar ()
+
+and bar () =
+  progress ();
+  foo ()
 ```
 
 That's becuse every infinite loop through either `foo`, or `bar`, makes progress infinitely often.
@@ -196,37 +183,32 @@ That's becuse every infinite loop through either `foo`, or `bar`, makes progress
 
 Does this always terminate?
 
-```rescript
-let next = _ => ()
+```ocaml
+let next _ = ()
 
 type token =
-  | Int(int)
-  | Float(float)
+  | Int of int
+  | Float of float
   | Eof
 
-type t = {token}
+type t = {token: token}
 
-@progress(next)
-let rec f = p =>
-  switch (p.token) {
-  | Int(i) => g(p) + i
-  | Eof => 0
-  | _ =>
-    next(p)
-    f(p)
-  }
+let[@progress next] rec f p =
+  match p.token with
+  | Int i -> g p + i
+  | Eof -> 0
+  | _ ->
+    next p;
+    f p
 
-and gParam = (p, ~g) => {
-  switch (p.token) {
-  | Int(i) => g(p) + i
-  | _ => f(p)
-  }
-}
+and gParam p ~g =
+  match p.token with
+  | Int i -> g p + i
+  | _ -> f p
 
-and g = p => {
-  next(p)
-  gParam(p, ~g)
-}
+and g p =
+  next p;
+  gParam p ~g
 ```
 
 According to the analysis, it does.
@@ -239,17 +221,15 @@ Another one is liveness.
 
 Here's an example of a server, which obviously never terminates, yet the analysis checks that it keeps on responding to requests:
 
-```rescript
+```ocaml
 type state
 type request
 
-let getRequest = (_: state): (request, state) => assert(false)
-let processRequest: request => unit = assert(false)
+let getRequest (_ : state) : request * state = assert false
+let processRequest : request -> unit = assert false
 
-@progress(getRequest)
-let rec server = state => {
-  let (request, state1) = getRequest(state)
-  processRequest(request)
-  server(state1)
-}
+let[@progress getRequest] rec server state =
+  let request, state1 = getRequest state in
+  processRequest request;
+  server state1
 ```

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,3 +1,3 @@
 # reanalyze
 
-Please refer to the [Github repository](https://github.com/cristianoc/reanalyze) for now.
+Please refer to the [Github repository](https://github.com/rescript-lang/reanalyze) for now.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reanalyze",
   "version": "2.25.1",
   "private": true,
-  "description": "Analyzers for Dead Code/Types and termination",
+  "description": "Analyzers for Dead Code/Types and termination in OCaml",
   "license": "MIT",
   "scripts": {
     "build": "dune build",
@@ -21,7 +21,7 @@
   },
   "author": "Cristiano Calcagno",
   "keywords": [
-    "rescript",
+    "ocaml",
     "tooling"
   ],
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "tooling"
   ],
   "bugs": {
-    "url": "https://github.com/cristianoc/reanalyze/issues"
+    "url": "https://github.com/rescript-lang/reanalyze/issues"
   },
-  "homepage": "https://github.com/cristianoc/reanalyze#readme"
+  "homepage": "https://github.com/rescript-lang/reanalyze#readme"
 }

--- a/reanalyze.opam
+++ b/reanalyze.opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-synopsis: "Dead values/types, exception, and termination analysis for OCaml/ReScript"
+synopsis: "Dead values/types, exception, and termination analysis for OCaml"
 description: """
-Experimental analyses for ReScript/OCaml/Reason: for globally dead values/types, exception analysis, and termination analysis.
+Experimental analyses for OCaml: for globally dead values/types, exception analysis, and termination analysis.
 """
 maintainer: ["Cristiano Calcagno"]
 authors: ["Cristiano Calcagno"]

--- a/reanalyze.opam
+++ b/reanalyze.opam
@@ -6,8 +6,8 @@ Experimental analyses for ReScript/OCaml/Reason: for globally dead values/types,
 maintainer: ["Cristiano Calcagno"]
 authors: ["Cristiano Calcagno"]
 license: "MIT"
-homepage: "https://github.com/rescript-association/reanalyze"
-bug-reports: "https://github.com/rescript-association/reanalyze/issues"
+homepage: "https://github.com/rescript-lang/reanalyze"
+bug-reports: "https://github.com/rescript-lang/reanalyze/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.08.0" & < "5.6"}
@@ -27,4 +27,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/rescript-association/reanalyze.git"
+dev-repo: "git+https://github.com/rescript-lang/reanalyze.git"

--- a/scripts/download_dist.js
+++ b/scripts/download_dist.js
@@ -12,7 +12,7 @@ const projectRoot = path.join(__dirname, "..");
 const filename = `reanalyze-v${pjson.version}.tgz`;
 
 const targetLink = (version) =>
-  `https://github.com/cristianoc/reanalyze/releases/download/v${version}/${filename}`;
+  `https://github.com/rescript-lang/reanalyze/releases/download/v${version}/${filename}`;
 
 const target = targetLink(pjson.version);
 


### PR DESCRIPTION
Two commits, both cleanup — no behavior change.

### 1. Point repository URLs at `rescript-lang/reanalyze`

The repo was transferred from `cristianoc/reanalyze` and `rescript-association/reanalyze`. Both old owners still return `Moved Permanently`, so nothing was broken, but the metadata (including the `homepage`/`dev-repo` published to `ocaml/opam-repository`) named paths that no longer exist. Updated in `reanalyze.opam`, `package.json`, `CONTRIBUTING.md`, `dist/README.md`, `scripts/download_dist.js`.

### 2. Drop ReScript from the docs and package metadata

This repository is now exclusively an OCaml analyzer — CI dropped the ReScript matrix and npm packaging in 1f91b56, and upstream already removed every `.res`/`.bs.js`/`bsconfig.json` fixture from `examples/`. The docs never followed, and still read as a ReScript tool.

- **README.md** — OCaml-only intro; one CLI section instead of separate ReScript/native ones; OCaml syntax throughout the DCE explanation (`| A of int`, `{x: int; y: int}`); `[@dead]`/`[@live]` attribute syntax; `.ml` paths. Removes the npm-install and "ReScript Projects (JS output)" sections, the `bsconfig.json` `-config` section, and the dead-code-ppx section — that ppx was deleted upstream, so the section documented a directory that no longer exists.
- **EXCEPTION.md / TERMINATION.md** — every example rewritten in OCaml (they were entirely ReScript syntax).
- **reanalyze.opam / package.json** — synopsis, description, keywords.

`Changes.md` is deliberately untouched: it is a historical record.

**Verification.** Every rewritten annotation example was run against the built analyzer rather than assumed. Confirmed recognized: `let[@raises A]`, `let[@raises (A, B)]`, `(String.make [@doesNotRaise]) 12 ' '`, bare `let[@progress]`, and `let[@progress f]`. The higher-order and liveness termination examples report 0 issues, as the surrounding text claims; the aliasing and Landin's-knot examples produce exactly the quoted hygiene violations. `opam lint` passes, `package.json` parses, `dune build` and `npm test` are green on OCaml 5.3.

### Left for a follow-up (deliberately not in this PR)

ReScript still exists in the *code*, which is a behavior change rather than a cleanup:

- `-config` reads `bsconfig.json` (`src/Paths.ml`, `src/Reanalyze.ml`) — the flag now has no documentation here, pending that decision.
- `src/ExnLib.ml` still vendors Belt, `Js.Json`, and `bs-json` exception models.
- `src/Exception.ml` prints suggestions in ReScript syntax: `@raises(A)`, not `[@raises A]`.
- `create-release.sh` and the `Dockerfile` build `reanalyze.native` from `src/lib/bs/native`, a BuckleScript-era path that cannot exist in this tree.

Note this collides with #197, which *adds* `rescript.json` support to `src/Paths.ml`.

First of two stacked PRs; #211 is based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ekre61YPcAuxSimHURmwq


Closes #209.
