### PR TITLE
Version 2.26.0

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,4 @@
-# Next
+# 2.26.0
 
 - Support OCaml 5.3, 5.4, and 5.5.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reanalyze",
-  "version": "2.25.1",
+  "version": "2.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reanalyze",
-      "version": "2.25.1",
+      "version": "2.26.0",
       "license": "MIT",
       "bin": {
         "reanalyze.exe": "_build/install/default/bin/reanalyze.exe"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reanalyze",
-  "version": "2.25.1",
+  "version": "2.26.0",
   "private": true,
   "description": "Analyzers for Dead Code/Types and termination in OCaml",
   "license": "MIT",

--- a/src/Version.ml
+++ b/src/Version.ml
@@ -2,4 +2,4 @@
 (* CREATED BY reanalyze/scripts/bump_version_module.js *)
 (* DO NOT MODIFY BY HAND, WILL BE AUTOMATICALLY UPDATED BY npm version *)
 
-let version = "2.25.1";
+let version = "2.26.0";


### PR DESCRIPTION
Stacked on #210 — **base is `chore/canonical-repo-urls`, not `master`.** Merge #210 first; this PR retargets to `master` automatically.

Cuts a release for the OCaml 5.3, 5.4, and 5.5 support that has accumulated on master since `v2.25.1` (2024-05-29, 24 commits back). The published opam package still carries `"ocaml" {>= "4.08.0" & < "5.3"}`, so `opam install reanalyze` currently fails on any 5.3+ switch; the widened `< "5.6"` bound only exists here on master. Minor bump, since this is added compiler support.

- `package.json` + `package-lock.json`: 2.25.1 → 2.26.0
- `src/Version.ml`: regenerated via `scripts/bump_version_module.js`
- `Changes.md`: `# Next` → `# 2.26.0`

Done by hand rather than with `npm version`, so no tag lands on this branch — tag `v2.26.0` on `master` after merge, then submit to `ocaml/opam-repository` (PR required there; we only have read access).

**Verified:** `dune build` green, built binary reports `reanalyze version 2.26.0`, `npm test` green on OCaml 5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ekre61YPcAuxSimHURmwq